### PR TITLE
feat: inventory form button ordering & cancel navigation fixes

### DIFF
--- a/frontend/src/components/InventoryForm.vue
+++ b/frontend/src/components/InventoryForm.vue
@@ -293,6 +293,16 @@ const handleSaveAndAddAnother = () => {
   saveItem()
 }
 
+const cancelForm = () => {
+  if (isEditMode.value) {
+    router.push(`/item/${item.value.id}`)
+  } else if (window.history.length > 1) {
+    router.back()
+  } else {
+    router.push('/inventory')
+  }
+}
+
 onMounted(async () => {
   try {
     const [partTypesRes, brandsRes, locationsRes, vendorsRes, projectsRes] = await Promise.all([
@@ -463,7 +473,7 @@ onMounted(async () => {
       <button
         type="button"
         class="btn btn-secondary"
-        @click="isEditMode ? router.push(`/item/${item.id}`) : (history.length > 1 ? router.back() : router.push('/inventory'))"
+        @click="cancelForm"
       >
         Cancel
       </button>

--- a/frontend/src/components/InventoryForm.vue
+++ b/frontend/src/components/InventoryForm.vue
@@ -452,6 +452,14 @@ onMounted(async () => {
     </div>
 
     <div class="form-actions">
+      <button
+        type="button"
+        class="btn btn-secondary"
+        @click="cancelForm"
+      >
+        Cancel
+      </button>
+
       <!-- Edit mode: Show filtered navigation buttons -->
       <button
         v-if="isEditMode && canNavigateBack"
@@ -468,14 +476,6 @@ onMounted(async () => {
         @click="handleSaveAndNext"
       >
         Save + Next
-      </button>
-
-      <button
-        type="button"
-        class="btn btn-secondary"
-        @click="cancelForm"
-      >
-        Cancel
       </button>
 
       <!-- Create mode: Show Save + Add Another button (also triggered by Ctrl+Enter) -->

--- a/frontend/src/components/InventoryForm.vue
+++ b/frontend/src/components/InventoryForm.vue
@@ -460,7 +460,7 @@ onMounted(async () => {
         Save + Next
       </button>
 
-      <RouterLink :to="isEditMode ? `/item/${item.id}` : '/'" class="btn btn-secondary">
+      <RouterLink :to="isEditMode ? `/item/${item.id}` : '/inventory'" class="btn btn-secondary">
         Cancel
       </RouterLink>
 

--- a/frontend/src/components/InventoryForm.vue
+++ b/frontend/src/components/InventoryForm.vue
@@ -314,7 +314,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <form ref="inventoryForm" @submit.prevent="saveItem" class="item-form">
+  <form ref="inventoryForm" @submit.prevent="saveItem" @keydown.ctrl.enter.prevent="!isEditMode && handleSaveAndAddAnother()" class="item-form">
     <div class="form-group">
       <label for="title">Title</label>
       <input id="title" v-model="item.title" type="text" required />
@@ -460,22 +460,23 @@ onMounted(async () => {
         Save + Next
       </button>
 
-      <!-- Always show Save button -->
-      <button type="submit" class="btn btn-primary">Save</button>
+      <RouterLink :to="isEditMode ? `/item/${item.id}` : '/'" class="btn btn-secondary">
+        Cancel
+      </RouterLink>
 
-      <!-- Create mode: Show Save + Add Another button -->
+      <!-- Create mode: Show Save + Add Another button (also triggered by Ctrl+Enter) -->
       <button
         v-if="!isEditMode"
         type="button"
         class="btn btn-success"
         @click="handleSaveAndAddAnother"
+        title="Save and add another item (Ctrl+Enter)"
       >
         Save + Add Another
       </button>
 
-      <RouterLink :to="isEditMode ? `/item/${item.id}` : '/'" class="btn btn-secondary">
-        Cancel
-      </RouterLink>
+      <!-- Always show Save button -->
+      <button type="submit" class="btn btn-primary">Save</button>
     </div>
   </form>
 </template>

--- a/frontend/src/components/InventoryForm.vue
+++ b/frontend/src/components/InventoryForm.vue
@@ -460,9 +460,13 @@ onMounted(async () => {
         Save + Next
       </button>
 
-      <RouterLink :to="isEditMode ? `/item/${item.id}` : '/inventory'" class="btn btn-secondary">
+      <button
+        type="button"
+        class="btn btn-secondary"
+        @click="isEditMode ? router.push(`/item/${item.id}`) : (history.length > 1 ? router.back() : router.push('/inventory'))"
+      >
         Cancel
-      </RouterLink>
+      </button>
 
       <!-- Create mode: Show Save + Add Another button (also triggered by Ctrl+Enter) -->
       <button

--- a/frontend/src/components/InventoryForm.vue
+++ b/frontend/src/components/InventoryForm.vue
@@ -296,7 +296,7 @@ const handleSaveAndAddAnother = () => {
 const cancelForm = () => {
   if (isEditMode.value) {
     router.push(`/item/${item.value.id}`)
-  } else if (window.history.length > 1) {
+  } else if (window.history.state?.back) {
     router.back()
   } else {
     router.push('/inventory')
@@ -324,7 +324,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <form ref="inventoryForm" @submit.prevent="saveItem" @keydown.ctrl.enter.prevent="!isEditMode && handleSaveAndAddAnother()" class="item-form">
+  <form ref="inventoryForm" @submit.prevent="saveItem" @keydown.ctrl.enter="(e) => { if (!isEditMode) { e.preventDefault(); handleSaveAndAddAnother() } }" class="item-form">
     <div class="form-group">
       <label for="title">Title</label>
       <input id="title" v-model="item.title" type="text" required />


### PR DESCRIPTION
## Summary

This PR merges `feature/inventory-import` into `main` with inventory form UX improvements focused on button ordering and cancel navigation.

## Changes

- **Button reorder** — Reordered `InventoryForm` buttons: Cancel first, then Save+Back/Next, then Save+Add Another
- **Ctrl+Enter shortcut** — Added `Ctrl+Enter` keyboard shortcut for Save+Add Another
- **Cancel routing fix** — Cancel on Add Inventory now routes to `/inventory` instead of the dashboard
- **Cancel URL filter restore** — Cancel on Add Inventory restores previous URL filters via `router.back()`
- **cancelForm() extraction** — Extracted `cancelForm()` to avoid undefined history reference in minified builds

## Type of Change

- [x] Bug fix
- [x] UX improvement