### PR TITLE
feat: configurable sidebar module visibility (Settings > Modules)

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -39,6 +39,7 @@ urlpatterns = [
     path('api/dashboard/', views.DashboardDataView.as_view(), name='dashboard'),
     path('api/alerts/dismiss/', views.DismissAlertView.as_view(), name='dismiss-alert'),
     path('api/alerts/dismiss-all/', views.DismissAllAlertsView.as_view(), name='dismiss-all-alerts'),
+    path('api/app-config/', views.AppConfigurationView.as_view(), name='app-config'),
     path('api/export/data/', views.ExportDataView.as_view(), name='export-data'),
     path('api/validate-backup/', views.ValidateBackupView.as_view(), name='validate-backup'),
     path('api/import-data/', views.ImportDataView.as_view(), name='import-data'),

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,12 +1,22 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { RouterLink, RouterView } from 'vue-router'
 import NotificationBell from '@/components/NotificationBell.vue'
 import APIService from '@/services/APIService.js'
+import { MODULES } from '@/config/modules.js'
+import { useAppConfig } from '@/composables/useAppConfig.js'
 
 const reminders = ref([])
 const lowStockItems = ref([])
 const isMobileMenuOpen = ref(false)
+
+// Sidebar module visibility (managed in Settings > Modules). Hidden modules
+// drop out of the nav; the Dashboard brand link and the Settings link live
+// outside this list and are always shown.
+const { hiddenModules, load: loadAppConfig } = useAppConfig()
+const visibleModules = computed(() =>
+  MODULES.filter((module) => !hiddenModules.value.includes(module.key)),
+)
 
 const fetchNotifications = async () => {
   try {
@@ -29,7 +39,10 @@ const closeMobileMenu = () => {
   isMobileMenuOpen.value = false
 }
 
-onMounted(fetchNotifications)
+onMounted(() => {
+  fetchNotifications()
+  loadAppConfig()
+})
 </script>
 
 <template>
@@ -50,11 +63,13 @@ onMounted(fetchNotifications)
           <h3>Print Vault</h3>
         </RouterLink>
       </div>
-      <RouterLink to="/inventory" @click="closeMobileMenu">Inventory</RouterLink>
-      <RouterLink to="/filaments" @click="closeMobileMenu">Filament</RouterLink>
-      <RouterLink to="/printers" @click="closeMobileMenu">Printers</RouterLink>
-      <RouterLink to="/projects" @click="closeMobileMenu">Projects</RouterLink>
-      <RouterLink to="/trackers" @click="closeMobileMenu">Print Trackers</RouterLink>
+      <RouterLink
+        v-for="module in visibleModules"
+        :key="module.key"
+        :to="module.to"
+        @click="closeMobileMenu"
+        >{{ module.label }}</RouterLink
+      >
       <div class="sidebar-spacer"></div>
       <RouterLink to="/settings" @click="closeMobileMenu" class="settings-menu-link"
         >Settings</RouterLink

--- a/frontend/src/components/ModulesTab.vue
+++ b/frontend/src/components/ModulesTab.vue
@@ -1,0 +1,159 @@
+<template>
+  <div class="modules-tab-container">
+    <div class="content-header">
+      <h3>Navigation Modules</h3>
+    </div>
+    <p class="description">
+      Show or hide top-level sections in the sidebar. Hiding a section only removes its
+      navigation link — its data and pages remain, and you can re-enable it here anytime.
+      Dashboard and Settings are always shown.
+    </p>
+
+    <div class="module-list">
+      <div v-for="module in modules" :key="module.key" class="module-item">
+        <div class="module-description">
+          <h4>{{ module.label }}</h4>
+          <p>{{ isHidden(module.key) ? 'Hidden from the sidebar' : 'Visible in the sidebar' }}</p>
+        </div>
+        <label class="switch" :title="`Toggle ${module.label}`">
+          <input
+            type="checkbox"
+            :checked="!isHidden(module.key)"
+            @change="onToggle(module.key, $event.target.checked)"
+          />
+          <span class="slider"></span>
+        </label>
+      </div>
+    </div>
+
+    <p v-if="error" class="error-text">{{ error }}</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { MODULES } from '@/config/modules.js'
+import { useAppConfig } from '@/composables/useAppConfig.js'
+
+const modules = MODULES
+const { isHidden, load, setHidden } = useAppConfig()
+const error = ref(null)
+
+// Checkbox "checked" means visible, so hidden is the inverse.
+const onToggle = async (key, visible) => {
+  error.value = null
+  try {
+    await setHidden(key, !visible)
+  } catch (err) {
+    console.error('Failed to update module visibility:', err)
+    error.value = 'Failed to save. Please try again.'
+  }
+}
+
+onMounted(() => {
+  load()
+})
+</script>
+
+<style scoped>
+.modules-tab-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.content-header h3 {
+  color: var(--color-heading);
+  margin-bottom: 0.5rem;
+}
+
+.description {
+  color: var(--color-text-muted, var(--color-text));
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.module-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.module-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 16px 20px;
+  border: 1px solid var(--color-border);
+  border-radius: 5px;
+}
+
+.module-description h4 {
+  color: var(--color-heading);
+  margin: 0 0 0.25rem 0;
+}
+
+.module-description p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted, var(--color-text));
+}
+
+/* Toggle switch (theme-aware via CSS variables) */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 46px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+  background-color: var(--color-background-mute);
+  border: 1px solid var(--color-border);
+  border-radius: 24px;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.slider::before {
+  content: '';
+  position: absolute;
+  height: 18px;
+  width: 18px;
+  left: 2px;
+  top: 2px;
+  background-color: var(--color-text);
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.switch input:checked + .slider {
+  background-color: var(--color-blue);
+  border-color: var(--color-blue);
+}
+
+.switch input:checked + .slider::before {
+  transform: translateX(22px);
+  background-color: #fff;
+}
+
+.switch input:focus-visible + .slider {
+  outline: 2px solid var(--color-blue);
+  outline-offset: 2px;
+}
+
+.error-text {
+  margin-top: 1rem;
+  color: var(--color-red);
+  font-size: 0.875rem;
+}
+</style>

--- a/frontend/src/composables/useAppConfig.js
+++ b/frontend/src/composables/useAppConfig.js
@@ -1,0 +1,49 @@
+import { ref } from 'vue'
+import APIService from '@/services/APIService.js'
+
+// Module-scoped singleton state (this project has no Pinia/Vuex). The same
+// reactive `hiddenModules` is shared by the sidebar (App.vue), the
+// Settings > Modules tab, and the Dashboard notice, so a change in one place is
+// reflected everywhere without a page reload.
+const hiddenModules = ref([])
+const loaded = ref(false)
+let inflight = null
+
+async function load(force = false) {
+  if (loaded.value && !force) return
+  if (inflight) return inflight
+  inflight = APIService.getAppConfig()
+    .then(({ data }) => {
+      hiddenModules.value = Array.isArray(data.hidden_modules) ? data.hidden_modules : []
+      loaded.value = true
+    })
+    .catch((error) => {
+      // Fail open: on any error default to all-visible so a backend hiccup can
+      // never hide the whole app. Leave loaded=false so a later call retries.
+      console.error('Failed to load app configuration:', error)
+      hiddenModules.value = []
+    })
+    .finally(() => {
+      inflight = null
+    })
+  return inflight
+}
+
+function isHidden(key) {
+  return hiddenModules.value.includes(key)
+}
+
+// Toggle one module's visibility and persist it. Optimistically returns the
+// server's saved state (the backend validates + de-dupes the list).
+async function setHidden(key, hidden) {
+  const next = hidden
+    ? [...new Set([...hiddenModules.value, key])]
+    : hiddenModules.value.filter((k) => k !== key)
+  const { data } = await APIService.updateAppConfig({ hidden_modules: next })
+  hiddenModules.value = Array.isArray(data.hidden_modules) ? data.hidden_modules : []
+  return hiddenModules.value
+}
+
+export function useAppConfig() {
+  return { hiddenModules, loaded, load, isHidden, setHidden }
+}

--- a/frontend/src/config/modules.js
+++ b/frontend/src/config/modules.js
@@ -1,0 +1,23 @@
+// Single source of truth for the sidebar's hideable modules.
+//
+// Dashboard and Settings are intentionally NOT listed here: they are
+// structurally always-visible. Settings must always be reachable so a user can
+// never lock themselves out of the toggle that re-enables modules; Dashboard is
+// the root-URL landing target (`/` redirects to `/dashboard`).
+//
+// Hiding a module only removes its sidebar link — its routes stay registered so
+// in-app deep links (e.g. a Project linking to a Printer) keep working.
+//
+// NOTE: 'library' is intentionally absent on this branch. The STL/3MF Library
+// ships on a separate feature branch; when it merges, add it here AND to
+// HIDEABLE_MODULE_KEYS in inventory/models.py so the backend allow-list agrees.
+export const MODULES = [
+  { key: 'inventory', label: 'Inventory', to: '/inventory' },
+  { key: 'filaments', label: 'Filament', to: '/filaments' },
+  { key: 'printers', label: 'Printers', to: '/printers' },
+  { key: 'projects', label: 'Projects', to: '/projects' },
+  { key: 'trackers', label: 'Print Trackers', to: '/trackers' },
+]
+
+// Keys that may be hidden — mirror of the backend HIDEABLE_MODULE_KEYS.
+export const HIDEABLE_KEYS = MODULES.map((m) => m.key)

--- a/frontend/src/services/APIService.js
+++ b/frontend/src/services/APIService.js
@@ -443,4 +443,12 @@ export default {
   getInventoryAllocation(inventoryItemId) {
     return apiClient.get(`inventoryitems/${inventoryItemId}/allocation/`)
   },
+
+  // App Configuration (sidebar module visibility, etc.)
+  getAppConfig() {
+    return apiClient.get('app-config/')
+  },
+  updateAppConfig(data) {
+    return apiClient.patch('app-config/', data)
+  },
 }

--- a/frontend/src/tests/composables/useAppConfig.spec.js
+++ b/frontend/src/tests/composables/useAppConfig.spec.js
@@ -1,0 +1,83 @@
+/**
+ * Tests for the useAppConfig composable (src/composables/useAppConfig.js).
+ *
+ * Covers: load() populating shared state, load() caching, fail-open on error,
+ * isHidden(), and setHidden() add/remove + PATCH persistence.
+ *
+ * NOTE: the composable holds module-scoped singleton state, so each test resets
+ * hiddenModules/loaded in beforeEach.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Inline factory (hoist-safe): creates fresh vi.fn()s with no outer references.
+vi.mock('@/services/APIService.js', () => ({
+  default: {
+    getAppConfig: vi.fn(),
+    updateAppConfig: vi.fn(),
+  },
+}))
+
+import APIService from '@/services/APIService.js'
+import { useAppConfig } from '@/composables/useAppConfig.js'
+
+describe('useAppConfig', () => {
+  let cfg
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cfg = useAppConfig()
+    // Reset the shared singleton state between tests.
+    cfg.hiddenModules.value = []
+    cfg.loaded.value = false
+  })
+
+  it('load() populates hiddenModules from the API', async () => {
+    APIService.getAppConfig.mockResolvedValue({ data: { hidden_modules: ['trackers'] } })
+    await cfg.load()
+    expect(cfg.hiddenModules.value).toEqual(['trackers'])
+    expect(cfg.loaded.value).toBe(true)
+  })
+
+  it('load() only calls the API once while loaded (cached)', async () => {
+    APIService.getAppConfig.mockResolvedValue({ data: { hidden_modules: [] } })
+    await cfg.load()
+    await cfg.load()
+    expect(APIService.getAppConfig).toHaveBeenCalledTimes(1)
+  })
+
+  it('load() fails open to all-visible on error, leaving loaded=false for retry', async () => {
+    APIService.getAppConfig.mockRejectedValue(new Error('network down'))
+    await cfg.load()
+    expect(cfg.hiddenModules.value).toEqual([])
+    expect(cfg.loaded.value).toBe(false)
+  })
+
+  it('isHidden() reflects the current hidden set', async () => {
+    APIService.getAppConfig.mockResolvedValue({ data: { hidden_modules: ['printers'] } })
+    await cfg.load()
+    expect(cfg.isHidden('printers')).toBe(true)
+    expect(cfg.isHidden('inventory')).toBe(false)
+  })
+
+  it('setHidden(key, true) adds the key and persists via PATCH', async () => {
+    APIService.updateAppConfig.mockResolvedValue({ data: { hidden_modules: ['projects'] } })
+    await cfg.setHidden('projects', true)
+    expect(APIService.updateAppConfig).toHaveBeenCalledWith({ hidden_modules: ['projects'] })
+    expect(cfg.hiddenModules.value).toEqual(['projects'])
+  })
+
+  it('setHidden(key, false) removes the key and persists via PATCH', async () => {
+    cfg.hiddenModules.value = ['projects', 'trackers']
+    APIService.updateAppConfig.mockResolvedValue({ data: { hidden_modules: ['trackers'] } })
+    await cfg.setHidden('projects', false)
+    expect(APIService.updateAppConfig).toHaveBeenCalledWith({ hidden_modules: ['trackers'] })
+    expect(cfg.hiddenModules.value).toEqual(['trackers'])
+  })
+
+  it('setHidden() does not duplicate an already-hidden key', async () => {
+    cfg.hiddenModules.value = ['projects']
+    APIService.updateAppConfig.mockResolvedValue({ data: { hidden_modules: ['projects'] } })
+    await cfg.setHidden('projects', true)
+    expect(APIService.updateAppConfig).toHaveBeenCalledWith({ hidden_modules: ['projects'] })
+  })
+})

--- a/frontend/src/tests/config/modules.spec.js
+++ b/frontend/src/tests/config/modules.spec.js
@@ -1,0 +1,38 @@
+/**
+ * Tests for the sidebar module registry (src/config/modules.js).
+ *
+ * The registry is the single source of truth for which top-level sections can
+ * be hidden. Dashboard and Settings must never appear here (they are
+ * structurally always-visible).
+ */
+import { describe, it, expect } from 'vitest'
+import { MODULES, HIDEABLE_KEYS } from '@/config/modules.js'
+
+describe('modules registry', () => {
+  it('lists the five hideable sidebar modules in order', () => {
+    expect(MODULES.map((m) => m.key)).toEqual([
+      'inventory',
+      'filaments',
+      'printers',
+      'projects',
+      'trackers',
+    ])
+  })
+
+  it('every module has a key, label and route path', () => {
+    for (const module of MODULES) {
+      expect(typeof module.key).toBe('string')
+      expect(typeof module.label).toBe('string')
+      expect(module.to.startsWith('/')).toBe(true)
+    }
+  })
+
+  it('derives HIDEABLE_KEYS from MODULES', () => {
+    expect(HIDEABLE_KEYS).toEqual(MODULES.map((m) => m.key))
+  })
+
+  it('never includes dashboard or settings (always-visible sections)', () => {
+    expect(HIDEABLE_KEYS).not.toContain('dashboard')
+    expect(HIDEABLE_KEYS).not.toContain('settings')
+  })
+})

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -4,8 +4,17 @@ import { useRouter } from 'vue-router'
 import BaseModal from '@/components/BaseModal.vue'
 import QuickAddInventoryModal from '@/components/QuickAddInventoryModal.vue'
 import APIService from '@/services/APIService'
+import { useAppConfig } from '@/composables/useAppConfig.js'
+import { MODULES } from '@/config/modules.js'
 
 const router = useRouter()
+
+// Sidebar module visibility (Settings > Modules) — drives the hidden-modules
+// notice below. Shared reactive state, so it updates live when toggled.
+const { hiddenModules, load: loadAppConfig } = useAppConfig()
+const hiddenModuleLabels = computed(() =>
+  MODULES.filter((m) => hiddenModules.value.includes(m.key)).map((m) => m.label),
+)
 
 // State
 const dashboardData = ref({
@@ -312,6 +321,7 @@ const createProject = () => {
 // Load dashboard data on mount
 onMounted(() => {
   loadDashboard()
+  loadAppConfig()
 })
 </script>
 
@@ -324,6 +334,17 @@ onMounted(() => {
 
     <!-- Dashboard Content -->
     <div v-else class="dashboard-content">
+      <!-- Hidden-modules notice: only shown when some sidebar sections are hidden -->
+      <div v-if="hiddenModuleLabels.length" class="hidden-modules-notice">
+        <span>
+          Some sections are hidden from navigation:
+          <strong>{{ hiddenModuleLabels.join(', ') }}</strong>.
+        </span>
+        <RouterLink to="/settings?tab=modules" class="hidden-modules-link">
+          Manage in Settings
+        </RouterLink>
+      </div>
+
       <!-- Mobile: Notifications Badge -->
       <div class="notifications-mobile">
         <div
@@ -744,6 +765,33 @@ onMounted(() => {
 
 <style scoped>
 /* Base Styles */
+.hidden-modules-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.6rem 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-alert-info);
+  border-radius: 6px;
+  background-color: var(--color-background-soft);
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.hidden-modules-link {
+  color: var(--color-blue);
+  text-decoration: none;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.hidden-modules-link:hover {
+  text-decoration: underline;
+}
+
 .dashboard-container {
   padding: 1rem;
   max-width: 1400px;

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from 'vue'
+import { useRoute } from 'vue-router'
 import MainHeader from '@/components/MainHeader.vue'
 import BrandsTab from '@/components/BrandsTab.vue'
 import PartTypesTab from '@/components/PartTypesTab.vue'
@@ -10,8 +11,16 @@ import FeaturesTab from '@/components/FeaturesTab.vue'
 import PreferencesTab from '@/components/PreferencesTab.vue'
 import DataManagementTab from '@/components/DataManagementTab.vue'
 import AboutTab from '@/components/AboutTab.vue'
+import ModulesTab from '@/components/ModulesTab.vue'
 
-const activeTab = ref('brands')
+const route = useRoute()
+// Allow deep-linking to a tab via ?tab=<key> (e.g. the Dashboard "hidden
+// modules" notice links to ?tab=modules). Fall back to Brands for unknown keys.
+const VALID_TABS = [
+  'brands', 'part-types', 'locations', 'materials', 'features',
+  'vendors', 'preferences', 'modules', 'data', 'about',
+]
+const activeTab = ref(VALID_TABS.includes(route.query.tab) ? route.query.tab : 'brands')
 </script>
 
 <template>
@@ -40,6 +49,9 @@ const activeTab = ref('brands')
         <button @click="activeTab = 'preferences'" :class="{ active: activeTab === 'preferences' }">
           Preferences
         </button>
+        <button @click="activeTab = 'modules'" :class="{ active: activeTab === 'modules' }">
+          Modules
+        </button>
         <button @click="activeTab = 'data'" :class="{ active: activeTab === 'data' }">
           Data Management
         </button>
@@ -55,6 +67,7 @@ const activeTab = ref('brands')
         <FeaturesTab v-if="activeTab === 'features'" />
         <VendorsTab v-if="activeTab === 'vendors'" />
         <PreferencesTab v-if="activeTab === 'preferences'" />
+        <ModulesTab v-if="activeTab === 'modules'" />
         <DataManagementTab v-if="activeTab === 'data'" />
         <AboutTab v-if="activeTab === 'about'" />
       </div>

--- a/inventory/migrations/0044_appconfiguration.py
+++ b/inventory/migrations/0044_appconfiguration.py
@@ -1,0 +1,34 @@
+# Hand-written (dev-environment convention: makemigrations is run by the user;
+# verify with `python manage.py makemigrations --check --dry-run`).
+# Adds the AppConfiguration singleton that stores install-wide UI settings —
+# currently sidebar module visibility (see
+# chat_docs/planning/MODULE_VISIBILITY_FEATURE_PLAN.md).
+#
+# NOTE ON MIGRATION NUMBER: this branch is cut from `main` (latest migration
+# 0043). The uncommitted STL/3MF Library feature on `feature/stl-library` ALSO
+# introduces a 0044 (and 0045-0047). When these branches are reconciled, one of
+# the two 0044s must be renumbered so the dependency chain stays linear.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('inventory', '0043_tracker_viewer_settings_trackerfileimage_auto_generated'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AppConfiguration',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('hidden_modules', models.JSONField(blank=True, default=list, help_text="List of sidebar module keys hidden from navigation, e.g. ['trackers', 'projects']. Empty list = every module visible. Stored as the HIDDEN set (not the visible set) so the default ([]) shows everything and unknown/legacy keys are simply ignored on read.")),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                'verbose_name': 'App Configuration',
+                'verbose_name_plural': 'App Configuration',
+            },
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -1678,3 +1678,54 @@ def update_tracker_stats_on_delete(sender, instance, **kwargs):
     tracker = instance.tracker
     tracker.recalculate_stats()
     tracker.save(update_fields=['total_quantity', 'printed_quantity_total', 'progress_percentage', 'updated_date'])
+
+
+# Sidebar modules that a user is allowed to hide from navigation. Dashboard and
+# Settings are deliberately excluded — they are structurally always-visible
+# (Settings so a user can never lock themselves out of this very toggle;
+# Dashboard because it is the root-URL landing target, `/` -> `/dashboard`).
+# NOTE: 'library' is intentionally absent on this branch — the STL/3MF Library
+# ships on a separate feature branch. When that feature merges, add 'library'
+# here AND to the frontend registry in frontend/src/config/modules.js.
+HIDEABLE_MODULE_KEYS = ['inventory', 'filaments', 'printers', 'projects', 'trackers']
+
+
+class AppConfiguration(models.Model):
+    """
+    Global, install-wide settings singleton (its row id is pinned to 1).
+
+    Print Vault has no per-user authentication, so app-level UI configuration
+    lives on a single shared row rather than a per-user preference. Currently it
+    holds sidebar module visibility; additional global settings can be added as
+    new fields here over time. If auth is ever introduced, this becomes the
+    basis for a per-user preference.
+    """
+    hidden_modules = models.JSONField(
+        default=list,
+        blank=True,
+        help_text=(
+            "List of sidebar module keys hidden from navigation, e.g. "
+            "['trackers', 'projects']. Empty list = every module visible. "
+            "Stored as the HIDDEN set (not the visible set) so the default ([]) "
+            "shows everything and unknown/legacy keys are simply ignored on read."
+        ),
+    )
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "App Configuration"
+        verbose_name_plural = "App Configuration"
+
+    def __str__(self):
+        return "App Configuration"
+
+    def save(self, *args, **kwargs):
+        # Enforce the singleton: there is only ever one AppConfiguration row.
+        self.pk = 1
+        super().save(*args, **kwargs)
+
+    @classmethod
+    def load(cls):
+        """Return the singleton row, creating it (all-visible default) if absent."""
+        obj, _ = cls.objects.get_or_create(pk=1)
+        return obj

--- a/inventory/serializers.py
+++ b/inventory/serializers.py
@@ -5,7 +5,8 @@ from django.utils import timezone
 from .models import (
     Brand, PartType, Location, Material, MaterialPhoto, MaterialFeature, Vendor, Printer, Mod, ModFile,
     InventoryItem, Project, ProjectLink, ProjectFile, ProjectInventory, ProjectPrinters,
-    ProjectBOMItem, Tracker, TrackerFile, TrackerFileImage, FilamentSpool
+    ProjectBOMItem, Tracker, TrackerFile, TrackerFileImage, FilamentSpool,
+    AppConfiguration, HIDEABLE_MODULE_KEYS
 )
 from .services.storage_manager import StorageManager, InsufficientStorageError, StoragePermissionError
 from .services.file_download_service import (
@@ -1264,8 +1265,37 @@ class TrackerListSerializer(serializers.ModelSerializer):
         model = Tracker
         fields = [
             'id', 'name', 'project', 'project_name', 'github_url', 'storage_type',
-            'progress_percentage', 'total_count', 'completed_count', 
+            'progress_percentage', 'total_count', 'completed_count',
             'total_quantity', 'printed_quantity_total', 'pending_quantity',
             'created_date'
         ]
         read_only_fields = ['created_date']
+
+
+class AppConfigurationSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the global AppConfiguration singleton.
+
+    Validates that every key in hidden_modules is an actually-hideable module.
+    Settings, Dashboard, and unknown keys are rejected, so a bad value (or a
+    tampered backup) can never hide a structural section or persist garbage.
+    Values are de-duplicated while preserving order.
+    """
+    class Meta:
+        model = AppConfiguration
+        fields = ['hidden_modules']
+
+    def validate_hidden_modules(self, value):
+        if not isinstance(value, list):
+            raise serializers.ValidationError("hidden_modules must be a list of module keys.")
+        invalid = [key for key in value if key not in HIDEABLE_MODULE_KEYS]
+        if invalid:
+            raise serializers.ValidationError(
+                f"Not hideable / unknown module keys: {invalid}. "
+                f"Allowed keys: {HIDEABLE_MODULE_KEYS}."
+            )
+        deduped = []
+        for key in value:
+            if key not in deduped:
+                deduped.append(key)
+        return deduped

--- a/inventory/tests/test_views/test_app_config.py
+++ b/inventory/tests/test_views/test_app_config.py
@@ -1,0 +1,198 @@
+"""
+Tests for the AppConfiguration singleton (sidebar module visibility) feature.
+
+Covers:
+- AppConfiguration model: singleton behaviour (pk pinned to 1), load(), default.
+- AppConfigurationSerializer: hideable allow-list validation + de-duplication.
+- GET/PATCH /api/app-config/ endpoint: read default, persist, reject bad keys.
+- Backup export/restore round-trip for the app_config.json section.
+
+See chat_docs/planning/MODULE_VISIBILITY_FEATURE_PLAN.md.
+"""
+import json
+import zipfile
+from io import BytesIO
+
+import pytest
+from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework.test import APIClient
+
+from inventory.models import AppConfiguration, HIDEABLE_MODULE_KEYS
+from inventory.serializers import AppConfigurationSerializer
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Model
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestAppConfigurationModel:
+    def test_save_pins_pk_to_1(self):
+        config = AppConfiguration()
+        config.save()
+        assert config.pk == 1
+
+    def test_two_saves_leave_one_row(self):
+        AppConfiguration().save()
+        AppConfiguration().save()
+        assert AppConfiguration.objects.count() == 1
+
+    def test_load_returns_singleton(self):
+        config = AppConfiguration.load()
+        assert config.pk == 1
+        # A second load() returns the same row, not a new one.
+        assert AppConfiguration.load().pk == 1
+        assert AppConfiguration.objects.count() == 1
+
+    def test_default_hidden_modules_is_empty_list(self):
+        assert AppConfiguration.load().hidden_modules == []
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Serializer
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestAppConfigurationSerializer:
+    def test_valid_subset_accepted(self):
+        serializer = AppConfigurationSerializer(data={"hidden_modules": ["inventory", "printers"]})
+        assert serializer.is_valid(), serializer.errors
+
+    def test_empty_list_accepted(self):
+        serializer = AppConfigurationSerializer(data={"hidden_modules": []})
+        assert serializer.is_valid(), serializer.errors
+
+    def test_unknown_key_rejected(self):
+        serializer = AppConfigurationSerializer(data={"hidden_modules": ["bogus"]})
+        assert not serializer.is_valid()
+        assert "hidden_modules" in serializer.errors
+
+    def test_settings_key_rejected(self):
+        # Settings must never be hideable — anti-lockout guarantee.
+        serializer = AppConfigurationSerializer(data={"hidden_modules": ["settings"]})
+        assert not serializer.is_valid()
+
+    def test_dashboard_key_rejected(self):
+        # Dashboard is the root-URL landing target and stays always-visible.
+        serializer = AppConfigurationSerializer(data={"hidden_modules": ["dashboard"]})
+        assert not serializer.is_valid()
+
+    def test_non_list_rejected(self):
+        serializer = AppConfigurationSerializer(data={"hidden_modules": "inventory"})
+        assert not serializer.is_valid()
+
+    def test_duplicates_deduped_preserving_order(self):
+        serializer = AppConfigurationSerializer(
+            data={"hidden_modules": ["printers", "printers", "inventory"]}
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["hidden_modules"] == ["printers", "inventory"]
+
+    def test_all_hideable_keys_are_accepted(self):
+        serializer = AppConfigurationSerializer(data={"hidden_modules": list(HIDEABLE_MODULE_KEYS)})
+        assert serializer.is_valid(), serializer.errors
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Endpoint: GET / PATCH /api/app-config/
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestAppConfigurationEndpoint:
+    def test_get_default_returns_empty(self, api_client):
+        response = api_client.get(reverse("app-config"))
+        assert response.status_code == 200
+        assert response.json()["hidden_modules"] == []
+
+    def test_patch_valid_persists(self, api_client):
+        url = reverse("app-config")
+        response = api_client.patch(url, {"hidden_modules": ["inventory", "printers"]}, format="json")
+        assert response.status_code == 200
+        assert response.json()["hidden_modules"] == ["inventory", "printers"]
+        # A follow-up GET reflects the saved state.
+        assert api_client.get(url).json()["hidden_modules"] == ["inventory", "printers"]
+
+    def test_patch_invalid_key_returns_400(self, api_client):
+        response = api_client.patch(reverse("app-config"), {"hidden_modules": ["bogus"]}, format="json")
+        assert response.status_code == 400
+
+    def test_patch_settings_returns_400(self, api_client):
+        response = api_client.patch(reverse("app-config"), {"hidden_modules": ["settings"]}, format="json")
+        assert response.status_code == 400
+
+    def test_patch_clearing_restores_all_visible(self, api_client):
+        url = reverse("app-config")
+        api_client.patch(url, {"hidden_modules": ["trackers"]}, format="json")
+        response = api_client.patch(url, {"hidden_modules": []}, format="json")
+        assert response.status_code == 200
+        assert response.json()["hidden_modules"] == []
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Backup export / restore round-trip (app_config.json section)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _make_backup_zip(members: dict) -> bytes:
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in members.items():
+            zf.writestr(name, content)
+    buf.seek(0)
+    return buf.read()
+
+
+@pytest.mark.django_db
+class TestAppConfigBackup:
+    def test_export_includes_app_config(self, api_client):
+        config = AppConfiguration.load()
+        config.hidden_modules = ["projects"]
+        config.save()
+
+        response = api_client.get(reverse("export-data"))
+        assert response.status_code == 200
+
+        with zipfile.ZipFile(BytesIO(response.content)) as zf:
+            assert "app_config.json" in zf.namelist()
+            data = json.loads(zf.read("app_config.json").decode("utf-8"))
+            assert data["hidden_modules"] == ["projects"]
+
+    def test_import_restores_app_config(self, api_client):
+        zip_bytes = _make_backup_zip(
+            {"app_config.json": json.dumps({"hidden_modules": ["trackers", "printers"]})}
+        )
+        upload = SimpleUploadedFile("backup.zip", zip_bytes, content_type="application/zip")
+
+        response = api_client.post(
+            reverse("import-data"), {"backup_file": upload}, format="multipart"
+        )
+        assert response.status_code == 200
+        assert AppConfiguration.load().hidden_modules == ["trackers", "printers"]
+
+    def test_import_filters_out_non_hideable_keys(self, api_client):
+        # A hand-edited / tampered backup can't sneak a non-hideable key past restore.
+        zip_bytes = _make_backup_zip(
+            {"app_config.json": json.dumps({"hidden_modules": ["settings", "trackers", "bogus"]})}
+        )
+        upload = SimpleUploadedFile("backup.zip", zip_bytes, content_type="application/zip")
+
+        response = api_client.post(
+            reverse("import-data"), {"backup_file": upload}, format="multipart"
+        )
+        assert response.status_code == 200
+        assert AppConfiguration.load().hidden_modules == ["trackers"]
+
+    def test_import_without_app_config_is_tolerated(self, api_client):
+        # Older backups won't have app_config.json — restore must not fail.
+        zip_bytes = _make_backup_zip({"README.txt": "no app config here"})
+        upload = SimpleUploadedFile("backup.zip", zip_bytes, content_type="application/zip")
+
+        response = api_client.post(
+            reverse("import-data"), {"backup_file": upload}, format="multipart"
+        )
+        assert response.status_code == 200

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -30,7 +30,8 @@ logger = logging.getLogger(__name__)
 from .models import (
     Brand, PartType, Location, Material, MaterialPhoto, MaterialFeature, Vendor, Printer, Mod, ModFile,
     InventoryItem, Project, ProjectLink, ProjectFile, ProjectInventory, ProjectPrinters,
-    ProjectBOMItem, Tracker, TrackerFile, TrackerFileImage, AlertDismissal, FilamentSpool
+    ProjectBOMItem, Tracker, TrackerFile, TrackerFileImage, AlertDismissal, FilamentSpool,
+    AppConfiguration, HIDEABLE_MODULE_KEYS
 )
 from .serializers import (
     BrandSerializer, PartTypeSerializer, LocationSerializer, MaterialSerializer, MaterialPhotoSerializer, MaterialFeatureSerializer, VendorSerializer, PrinterSerializer, ModSerializer, ModFileSerializer,
@@ -38,7 +39,7 @@ from .serializers import (
     ProjectInventorySerializer, ProjectPrintersSerializer, ProjectBOMItemSerializer,
     TrackerSerializer, TrackerFileSerializer, TrackerFileImageSerializer,
     TrackerCreateSerializer, TrackerListSerializer,
-    FilamentSpoolSerializer
+    FilamentSpoolSerializer, AppConfigurationSerializer
 )
 from .filters import InventoryItemFilter, PrinterFilter, ProjectFilter
 from .services.github_service import (
@@ -297,6 +298,16 @@ class ExportDataView(APIView):
             except Exception as e:
                 logger.error(f"Failed to export tracker files section: {e}", exc_info=True)
                 export_errors.append("trackerfiles_section")
+
+            # Export App Configuration (global settings singleton: module visibility, etc.)
+            try:
+                config = AppConfiguration.load()
+                zf.writestr('app_config.json', json.dumps({
+                    'hidden_modules': config.hidden_modules,
+                }, indent=2))
+            except Exception as e:
+                logger.error(f"Failed to export app configuration: {e}", exc_info=True)
+                export_errors.append("app_config_section")
 
             # Add media files to zip
             try:
@@ -1521,6 +1532,20 @@ class ImportDataView(APIView):
                         with open(target_path, 'wb') as f:
                             f.write(zf.read(member))
 
+                # Restore App Configuration (module visibility, etc.) if present.
+                # Optional section — older backups won't have it; never fail the import.
+                try:
+                    if 'app_config.json' in zf.namelist():
+                        cfg_data = json.loads(zf.read('app_config.json').decode('utf-8'))
+                        hidden = cfg_data.get('hidden_modules', [])
+                        if isinstance(hidden, list):
+                            config = AppConfiguration.load()
+                            config.hidden_modules = [k for k in hidden if k in HIDEABLE_MODULE_KEYS]
+                            config.save()
+                except Exception as e:
+                    logger.error(f"Failed to import app configuration: {e}", exc_info=True)
+                    import_errors.append("app_config_section")
+
                 def read_csv_from_zip(zipfile_obj, filename):
                     with zipfile_obj.open(filename, 'r') as f:
                         reader = csv.reader(StringIO(f.read().decode('utf-8')))
@@ -1900,6 +1925,31 @@ class ImportDataView(APIView):
         except Exception as e:
             logger.error(f"Import failed completely: {e}", exc_info=True)
             return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+class AppConfigurationView(APIView):
+    """
+    Global app configuration singleton (currently sidebar module visibility).
+
+    GET   /api/app-config/  -> {"hidden_modules": [...]}
+    PATCH /api/app-config/  -> update hidden_modules; returns the saved state.
+
+    There is only ever one row (AppConfiguration.load()); the serializer
+    validates that every hidden key is an actually-hideable module, so Settings,
+    Dashboard, and unknown keys can never be persisted as hidden.
+    """
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        config = AppConfiguration.load()
+        return Response(AppConfigurationSerializer(config).data)
+
+    def patch(self, request):
+        config = AppConfiguration.load()
+        serializer = AppConfigurationSerializer(config, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
+
 
 class DeleteAllData(APIView):
     permission_classes = [AllowAny]


### PR DESCRIPTION
## Summary

Adds configurable **sidebar module visibility** — a **Settings → Modules** tab where you can show/hide top-level sections you don't use. Broadly useful (declutter), and it de-risks future niche features: they become optional modules instead of universal bloat.

## What's included

- **Backend**: `AppConfiguration` singleton (`hidden_modules` JSON field), `GET`/`PATCH /api/app-config/`, a serializer with a hideable allow-list (rejects `settings`/`dashboard`/unknown keys, de-dupes), and inclusion in backup export/restore. Migration `0044_appconfiguration`.
- **Frontend**: module registry (`config/modules.js`), a shared `useAppConfig` composable (no Pinia in this project), the sidebar filtered in `App.vue`, `ModulesTab.vue` toggles, and a Dashboard notice shown while any module is hidden (deep-links to `Settings?tab=modules`).
- **Tests**: backend (model singleton, serializer validation, endpoint, backup round-trip); frontend (registry + composable). Backend suite green locally (`21 passed`).

## Design decisions

- **Global, not per-user** — the app has no auth, so this is one install-wide singleton.
- **Stores the hidden set** (default `[]` = all visible) so fresh installs and old backups need no seeding, and unknown keys are ignored on read / rejected on write.
- **Dashboard & Settings are structurally non-hideable** — anti-lockout (Settings) and root-URL landing target (Dashboard).
- **Hides nav links only** — routes stay registered so in-app deep links (e.g. Project → Printer) never break.
- **Fails open** (all-visible) if the config fetch errors, so a backend hiccup never hides the whole app.

## ⚠️ Reconciliation notes (concurrent STL-library branch)

- Cut from `main`, so the **STL/3MF `library` module is intentionally absent**. Add `'library'` to `HIDEABLE_MODULE_KEYS` (`inventory/models.py`) and `MODULES` (`frontend/src/config/modules.js`) when that feature merges — comments mark both spots.
- Migration **`0044_appconfiguration` collides by number** with the STL-library branch's `0044_library_models`. Renumber one when reconciling the branches.

## How to test

- Backend: `pytest inventory/tests/test_views/test_app_config.py`
- Manual: Settings → Modules → toggle a section off → its sidebar link disappears live and the Dashboard shows a "sections hidden" notice. Verified in light + dark mode.
